### PR TITLE
Fix for potential error

### DIFF
--- a/Utils.Torch/VRageUtils.cs
+++ b/Utils.Torch/VRageUtils.cs
@@ -419,7 +419,8 @@ namespace Utils.Torch
         public static IEnumerable<IMyEntity> GetEntities(this HkWorld world)
         {
             var entities = new List<IMyEntity>();
-            foreach (var rigidBody in world.RigidBodies)
+            var rigidbodies = world.RigidBodies.ToList();
+            foreach (var rigidBody in rigidbodies)
             {
                 var body = rigidBody.GetBody();
                 var entity = body.Entity;


### PR DESCRIPTION
Fixing potential collection modified error observed happening during async operation in torch monitor

Error is as follows, 

System.InvalidOperationException: Collection was modified; enumeration operation may not execute.    at System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource)    at System.Collections.Generic.List1.Enumerator.MoveNextRare()    at 
Utils.Torch.VRageUtils.GetEntities(HkWorld world) in E:\Torch MAIN\TorchMonitor\TorchUtils\Utils.Torch\VRageUtils.cs:line 422    at TorchMonitor.Utils.PhysicsUtils.TryGetHeaviestGrid(HkWorld world, IMyCubeGrid& heaviestGrid) in E:\Torch MAIN\TorchMonitor\TorchMonitor\TorchMonitor.Utils\PhysicsUtils.cs:line 12    at TorchMonitor.ProfilerMonitors.PhysicsSimulateMtProfilerMonitor.OnProfilingFinished(BaseProfilerResult1 result) in E:\Torch MAIN\TorchMonitor\TorchMonitor\TorchMonitor.ProfilerMonitors\PhysicsSimulateMtProfilerMonitor.cs:line 24    at TorchMonitor.ProfilerMonitors.ProfilerMonitorBase`1.<Profile>d__4.MoveNext() in E:\Torch MAIN\TorchMonitor\TorchMonitor\TorchMonitor.ProfilerMonitors\ProfilerMonitorBase.cs:line 35

Caught this error in torch monitor using a rider debugger, it seems to be a simple edge case error caused by not cloning the list before iterating it. Guessing based on context that it is the cause of a number of repeated silent crashes on our servers which run torch monitor.